### PR TITLE
Fix a few specific bugs with attribute name changes

### DIFF
--- a/arvi/gaia_wrapper.py
+++ b/arvi/gaia_wrapper.py
@@ -48,7 +48,7 @@ def run_query(query):
     url = 'https://gea.esac.esa.int/tap-server/tap/sync'
     data = dict(query=query, request='doQuery', lang='ADQL', format='csv')
     try:
-        response = requests.post(url, data=data, timeout=2)
+        response = requests.post(url, data=data, timeout=30)
     except requests.ReadTimeout as err:
         raise IndexError(err)
     except requests.ConnectionError as err:

--- a/arvi/simbad_wrapper.py
+++ b/arvi/simbad_wrapper.py
@@ -111,7 +111,7 @@ def run_query(query, SIMBAD_URL='http://simbad.u-strasbg.fr'):
     url = f'{SIMBAD_URL}/simbad/sim-tap/sync'
     data = dict(query=query, request='doQuery', lang='ADQL', format='text/plain', phase='run')
     try:
-        response = requests.post(url, data=data, timeout=2)
+        response = requests.post(url, data=data, timeout=30)
     except requests.ReadTimeout as err:
         raise IndexError(err) from None
     except requests.ConnectionError as err:

--- a/arvi/timeseries.py
+++ b/arvi/timeseries.py
@@ -1691,21 +1691,31 @@ class RV(ISSUES, REPORTS):
     def remove_prog_id(self, prog_id):
         """ Remove observations from a given program ID """
         from glob import has_magic
+
+        if hasattr(self, 'prog_id'):
+            prog_id_attr = 'prog_id'
+        elif hasattr(self, 'program_id'):
+            prog_id_attr = 'program_id'
+        else:   
+            if self.verbose:
+                logger.warning(f'no program ID attribute found in {self} - unable to remove observations for program "{prog_id}"')
+            return
+        
         if has_magic(prog_id):
             from fnmatch import filter
-            matching = np.unique(filter(self.prog_id, prog_id))
+            matching = np.unique(filter(getattr(self, prog_id_attr), prog_id))
             mask = np.full_like(self.time, False, dtype=bool)
             for m in matching:
-                mask |= np.isin(self.prog_id, m)
+                mask |= np.isin(getattr(self, prog_id_attr), m)
             ind = np.where(mask)[0]
             self.remove_point(ind)
         else:
-            if prog_id in self.prog_id:
-                ind = np.where(self.prog_id == prog_id)[0]
+            if prog_id in getattr(self, prog_id_attr):
+                ind = np.where(getattr(self, prog_id_attr) == prog_id)[0]
                 self.remove_point(ind)
             else:
                 if self.verbose:
-                    logger.warning(f'no observations for prog_id "{prog_id}"')
+                    logger.warning(f'no observations for {prog_id_attr} "{prog_id}"')
 
     def remove_after_bjd(self, bjd: float):
         """ Remove observations after a given BJD """

--- a/arvi/timeseries.py
+++ b/arvi/timeseries.py
@@ -2596,11 +2596,11 @@ class RV(ISSUES, REPORTS):
                 "berv",
             ],
             "CORALIE": [
-                "fwhm", "fwhm_err",
-                "bispan", "bispan_err",
-                "contrast", "contrast_err",
-                "haindex", "haindex_err",
-                "berv",
+                "ccf_fwhm", "ccf_fwhm_err",
+                "ccf_bispan", "ccf_bispan_err",
+                "ccf_contrast", "ccf_contrast_err",
+                "spectro_halpha", "spectro_halpha_err",
+                "cal_berv",
             ],
         } 
 


### PR DESCRIPTION
I stumbled upon some new bugs after finally rerunning my RV data querying pipeline (the first time doing so in 5 months):

1. It seems that the RV object attribute "prog_id" is now "program_id", although this change does not appear to originate from any updates to `arvi` in the past 5 months.  It must be a change originating in the new updates to `astro-dace/dace-query`; I assume this attribute is propagated directly to the resulting RV object without any definition/naming by `arvi` itself.  The change I have made to the function `remove_prog_id` accounts for this new naming scheme in DACE data, while also still working for data from other sources, i.e. data where the attribute may still called be "prog_id".

2. When saving an RV object to a rdb file, the indicator names are outdated in the `save` function.  I made the most minimal change possible - I only changed these outdated attribute names in the `save` function (no where else in the code), and only for CORALIE data.  @j-faria : please let me know if assuming that the old attribute names "haindex", "haindex_err", "berv" do indeed correspond to "spectro_halpha", "spectro_halpha_err", "cal_berv", respectively, or not (otherwise, this fix is wrong).